### PR TITLE
fix: companion changes for Renovate PR #269

### DIFF
--- a/apps/base/immich/helmrelease.yaml
+++ b/apps/base/immich/helmrelease.yaml
@@ -51,11 +51,8 @@ spec:
       - secretRef:
           name: immich-db-url
 
-    redis:
+    valkey:
       enabled: true
-      architecture: standalone
-      auth:
-        enabled: false
 
     machine-learning:
       enabled: false

--- a/apps/base/immich/servers-deployment.yaml
+++ b/apps/base/immich/servers-deployment.yaml
@@ -27,7 +27,7 @@ spec:
             - name: IMMICH_WORKERS_EXCLUDE
               value: "microservices"
             - name: REDIS_HOSTNAME
-              value: immich-redis-master
+              value: immich-valkey
             - name: DB_URL
               valueFrom:
                 secretKeyRef:

--- a/apps/base/immich/workers-deployment.yaml
+++ b/apps/base/immich/workers-deployment.yaml
@@ -27,7 +27,7 @@ spec:
             - name: IMMICH_WORKERS_EXCLUDE
               value: "api"
             - name: REDIS_HOSTNAME
-              value: immich-redis-master
+              value: immich-valkey
             - name: DB_URL
               valueFrom:
                 secretKeyRef:


### PR DESCRIPTION
## Summary
- switch the Immich chart values from the removed Redis subchart to the new Valkey dependency
- update the manually managed Immich server and worker deployments to use `immich-valkey`
- keep the change minimal and scoped to the chart breaking change in Renovate PR #269

## Why
Immich chart `0.10.0+` removes the Redis subchart and replaces it with Valkey. This repo still referenced the old `immich-redis-master` service from manually managed Immich workloads, so the Renovate update needs a small companion fix before it is safe to merge.

## Related
- Renovate PR: #269