### PR TITLE
docs: refresh homelab documentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# Homelab (Under Heavy Construction 🚧)
+# Homelab
 
 This repository contains my personal _in-progress_ homelab setup, intended to showcase my **DevOps** and **Cloud Native** learning journey. The setup uses **Ansible** to provision a lightweight Kubernetes cluster (via K3s) and **Flux** (with Kustomize) to manage application and infrastructure deployments in a GitOps manner.
 
@@ -123,7 +123,7 @@ This repository contains my personal _in-progress_ homelab setup, intended to sh
 ### apps
 
 - **base/**  
-  Kustomize bases for each application and externally fronted service: Blog, External-Service, Glance, Homepage, Immich, Linkwarden, n8n, test manifests, Vaultwarden, and Vaultwarden testing.
+  Kustomize bases for each application and externally fronted service: Blog, External-Service, Glance, Homepage, Immich, Linkwarden, n8n, and Vaultwarden.
 - **the-big-ship/**  
   Environment-specific overlays referencing those bases, often patching or adding configs (e.g., `homepage/configmap.yaml` and `glance/configmap.yaml`) for the main cluster environment.
 
@@ -137,8 +137,6 @@ This repository contains my personal _in-progress_ homelab setup, intended to sh
     Flux Kustomization to deploy cluster infrastructure (cert-manager, traefik, etc.).
   - **flux-system/**  
     Flux bootstrap manifests (`gotk-components.yaml`, `gotk-sync.yaml`, and `kustomization.yaml`).
-  - **hugo-image.yaml**, **hugo-policy.yaml**, **hugo-auto-update.yaml**  
-    Flux image automation resources for the blog image.
 
 ### database
 

--- a/README.md
+++ b/README.md
@@ -12,15 +12,16 @@ This repository contains my personal _in-progress_ homelab setup, intended to sh
    - [apps](#apps)
    - [clusters](#clusters)
    - [database](#database)
+   - [docs](#docs)
    - [infrastructure](#infrastructure)
    - [networking](#networking)
+   - [templates](#templates)
 3. [Key Technologies](#key-technologies)
 4. [Getting Started](#getting-started)
    - [Prerequisites](#prerequisites)
    - [Installation & Usage](#installation--usage)
 5. [Current Status & Roadmap](#current-status--roadmap)
-6. [License](#license)
-7. [Contact](#contact)
+6. [Contact](#contact)
 
 ---
 
@@ -89,11 +90,16 @@ This repository contains my personal _in-progress_ homelab setup, intended to sh
 ├── database
 │   ├── base/        # Base definitions for CloudNativePG clusters
 │   └── the-big-ship/ # Overlays to deploy database instances for various apps
+├── docs
+│   ├── README.md    # Index for architecture, networking, storage, and ops docs
+│   └── *.md         # Focused homelab design and operations writeups
 ├── infrastructure
 │   ├── base/        # HelmRelease definitions (cert-manager, traefik, longhorn, etc.)
 │   └── the-big-ship/ # Overlays for production / main cluster environment
-└── networking
-    └── README.md    # Home network architecture (pfSense, Pi-hole, Proxmox, Tailscale)
+├── networking
+│   └── README.md    # Detailed home network architecture (pfSense, Pi-hole, Proxmox, Tailscale)
+└── templates
+    └── k8s.yaml     # Starter template for new Kubernetes app manifests
 ```
 
 ### ansible-k8s
@@ -117,18 +123,22 @@ This repository contains my personal _in-progress_ homelab setup, intended to sh
 ### apps
 
 - **base/**  
-  Kustomize bases for each application: Blog, External-Service, Glance, Homepage, Immich, Linkwarden, n8n, Vaultwarden.
+  Kustomize bases for each application and externally fronted service: Blog, External-Service, Glance, Homepage, Immich, Linkwarden, n8n, test manifests, Vaultwarden, and Vaultwarden testing.
 - **the-big-ship/**  
-  Overlays referencing `base` folders, often patching or adding configs (e.g., `homepage/configmap.yaml`) for the production environment.
+  Environment-specific overlays referencing those bases, often patching or adding configs (e.g., `homepage/configmap.yaml` and `glance/configmap.yaml`) for the main cluster environment.
 
 ### clusters
 
 - **the-big-ship/**  
   Flux Kustomization manifests that watch and apply changes from `apps/the-big-ship`, `database/the-big-ship`, and `infrastructure/the-big-ship`. Includes:
   - **apps-kus.yaml** & **database-kus.yaml**  
-    Kustomizations to deploy apps and databases.
+    Flux Kustomizations to deploy apps and databases.
   - **infrastructure-kus.yaml**  
-    Kustomization to deploy cluster infrastructure (cert-manager, traefik, etc.).
+    Flux Kustomization to deploy cluster infrastructure (cert-manager, traefik, etc.).
+  - **flux-system/**  
+    Flux bootstrap manifests (`gotk-components.yaml`, `gotk-sync.yaml`, and `kustomization.yaml`).
+  - **hugo-image.yaml**, **hugo-policy.yaml**, **hugo-auto-update.yaml**  
+    Flux image automation resources for the blog image.
 
 ### database
 
@@ -141,6 +151,13 @@ This repository contains my personal _in-progress_ homelab setup, intended to sh
   - **playground/** — Example PostgreSQL cluster for testing purposes
 - **the-big-ship/**  
   Environment overlays for each database cluster.
+
+### docs
+
+- **README.md**  
+  Entry point for the repo’s architecture, networking, storage, services, ingress, and operations documentation.
+- **`*.md`**  
+  Focused design notes that complement the top-level README with shorter, task-specific explanations.
 
 ### infrastructure
 
@@ -155,12 +172,17 @@ This repository contains my personal _in-progress_ homelab setup, intended to sh
   - **external-secrets**
   - **descheduler**
 - **the-big-ship/**  
-  Kustomize overlays that adapt the base HelmRelease definitions to the environment, including a `certificate/` overlay for cluster-wide TLS certificates.
+  Kustomize overlays that adapt the base HelmRelease definitions to the environment, including a `certificate/` overlay for service TLS certificates.
 
 ### networking
 
 - **README.md**  
   Documents the home network architecture: Proxmox bridge setup, pfSense firewall and Unbound DNS, Pi-hole ad blocking, VLAN/subnet layout, firewall rules, and Tailscale integration. See [networking/README.md](networking/README.md).
+
+### templates
+
+- **k8s.yaml**  
+  A starter manifest template for adding new Kubernetes applications or services to the repo.
 
 ---
 
@@ -266,12 +288,6 @@ This repository contains my personal _in-progress_ homelab setup, intended to sh
 - [ ] Implement alert rules for each monitored service.
 - [ ] Integrate log aggregation with Loki.
 - [ ] Implement backup and disaster recovery for each service.
-
----
-
-## License
-
-[MIT License](LICENSE) © 2025 [Wyson Cheng]
 
 ---
 

--- a/docs/README.md
+++ b/docs/README.md
@@ -1,5 +1,8 @@
 # Homelab Documentation
 
+This directory holds the concise architecture and operations writeups for the repo.
+For the deeper pfSense / Pi-hole / Proxmox network walkthrough, also see [`../networking/README.md`](../networking/README.md).
+
 ## Documents
 - [Overall Architecture](architecture-overview.md) — high-level system design and key layers.
 - [Cluster Architecture](cluster-architecture.md) — K3s topology and management model.

--- a/docs/services-running.md
+++ b/docs/services-running.md
@@ -9,13 +9,27 @@ These are the confirmed platform services running in K3s:
 - **cert-manager** (public TLS automation)
 - **FluxCD** (GitOps reconciliation)
 - **Longhorn** (persistent storage)
+- **CloudNativePG** (PostgreSQL operator)
+- **external-secrets** (secret sync)
 - **Prometheus** (metrics collection)
 - **Grafana** (dashboards and visualization)
+- **descheduler** (periodic workload rebalancing)
 
-K3s hosts most application workloads, but the full in-cluster app list is intentionally not over-specified here.
+## In-cluster application workloads
+The repo currently contains application manifests or overlays for:
+- **Blog**
+- **Glance**
+- **Homepage**
+- **Immich**
+- **Linkwarden**
+- **n8n**
+- **Vaultwarden**
+- **Vaultwarden testing**
+- **test** manifests
+- **external-service** routes for selected services that live outside Kubernetes
 
 ## Services outside Kubernetes
-These services run outside the cluster for operational or architectural reasons:
+These services run outside the cluster for operational or architectural reasons and are represented in the repo where ingress or documentation is needed:
 - **pfSense** on Proxmox (network edge)
 - **Pi-hole** in Proxmox LXC (DNS)
 - **Uptime Kuma** in Proxmox LXC (service monitoring)

--- a/docs/services-running.md
+++ b/docs/services-running.md
@@ -24,12 +24,10 @@ The repo currently contains application manifests or overlays for:
 - **Linkwarden**
 - **n8n**
 - **Vaultwarden**
-- **Vaultwarden testing**
-- **test** manifests
 - **external-service** routes for selected services that live outside Kubernetes
 
 ## Services outside Kubernetes
-These services run outside the cluster for operational or architectural reasons and are represented in the repo where ingress or documentation is needed:
+These services run outside the cluster for operational or architectural reasons:
 - **pfSense** on Proxmox (network edge)
 - **Pi-hole** in Proxmox LXC (DNS)
 - **Uptime Kuma** in Proxmox LXC (service monitoring)


### PR DESCRIPTION
## Summary
- refresh the top-level README structure overview
- add context to docs/README.md
- expand services-running.md with platform and workload details