### PR TITLE
fix(apps): add Vaultwarden admin token secret

### DIFF
--- a/apps/base/vaultwarden/admin-secret.yaml
+++ b/apps/base/vaultwarden/admin-secret.yaml
@@ -1,0 +1,17 @@
+apiVersion: external-secrets.io/v1
+kind: ExternalSecret
+metadata:
+  name: vaultwarden-admin-secret
+  namespace: apps
+spec:
+  refreshInterval: "1h"
+  secretStoreRef:
+    name: azure-kv-store
+    kind: ClusterSecretStore
+  target:
+    name: vaultwarden-secret
+    creationPolicy: Owner
+  data:
+    - secretKey: ADMIN_TOKEN
+      remoteRef:
+        key: vaultwarden-admin-token

--- a/apps/base/vaultwarden/kustomization.yaml
+++ b/apps/base/vaultwarden/kustomization.yaml
@@ -6,3 +6,4 @@ resources:
   - ingress.yaml
   - storage-lh.yaml
   - secret.yaml
+  - admin-secret.yaml


### PR DESCRIPTION
## Summary
- Add a dedicated `ExternalSecret` for Vaultwarden's `ADMIN_TOKEN`
- Target the Kubernetes Secret expected by the deployment: `vaultwarden-secret`
- Include the new manifest in the Vaultwarden base kustomization

## Context
After restoring the `apps` namespace and binding the restored Longhorn PVC, Vaultwarden schedules successfully but fails with:

```text
Error: secret "vaultwarden-secret" not found
```

The deployment already references `vaultwarden-secret` / `ADMIN_TOKEN`; this PR creates that secret from Azure Key Vault key `vaultwarden-admin-token`.

## Validation
- `kubectl kustomize apps/base/vaultwarden`
- `kubectl kustomize apps/the-big-ship/vaultwarden`