### PR TITLE
fix(n8n): store binary data on disposable volume

### DIFF
--- a/apps/base/n8n/deployment.yaml
+++ b/apps/base/n8n/deployment.yaml
@@ -18,10 +18,12 @@ spec:
       initContainers:
         - name: volume-permissions
           image: busybox:1.38
-          command: ["sh", "-c", "chown -R 1000:1000 /data"]
+          command: ["sh", "-c", "chown -R 1000:1000 /data /binary-data"]
           volumeMounts:
             - name: n8n-pvc-longhorn
               mountPath: /data
+            - name: n8n-binary-data
+              mountPath: /binary-data
       containers:
         - name: n8n
           image: n8nio/n8n:2.30.0
@@ -46,6 +48,8 @@ spec:
               value: "https://n8n.ysonsbaolab.dev"
             - name: N8N_DEFAULT_BINARY_DATA_MODE
               value: filesystem
+            - name: N8N_BINARY_DATA_STORAGE_PATH
+              value: /home/node/.n8n/binaryData
           resources:
             requests:
               cpu: 200m
@@ -56,8 +60,13 @@ spec:
           volumeMounts:
             - name: n8n-pvc-longhorn
               mountPath: /home/node/.n8n
+            - name: n8n-binary-data
+              mountPath: /home/node/.n8n/binaryData
       restartPolicy: Always
       volumes:
         - name: n8n-pvc-longhorn
           persistentVolumeClaim:
             claimName: n8n-pvc-longhorn-bk
+        - name: n8n-binary-data
+          emptyDir:
+            sizeLimit: 5Gi


### PR DESCRIPTION
## Summary
- Set n8n binary storage path to `/home/node/.n8n/binaryData`
- Mount a 5Gi `emptyDir` at that path for disposable binary payloads
- Update the permissions init container to chown the binary-data volume

## Why
Google Drive downloads can fill the Longhorn-backed n8n home volume when binary data is stored on the default filesystem path. Binary payloads are disposable here, so keeping them on a capped ephemeral volume avoids consuming persistent Longhorn storage.

## Validation
- `git diff --check -- apps/base/n8n/deployment.yaml`
- `kubectl kustomize apps/the-big-ship/n8n`
