### PR TITLE
docs: remove Homepage references

### DIFF
--- a/README.md
+++ b/README.md
@@ -73,7 +73,6 @@ This repository contains the infrastructure-as-code and GitOps configuration for
 - **AI Agent View**
 - **Blog** — Hugo-based site
 - **Glance** — dashboard and start page
-- **Homepage** — service dashboard
 - **Immich** — photo management
 - **n8n** — workflow automation, including Renovate PR checks
 - **Vaultwarden** — Bitwarden-compatible password manager

--- a/docs/services-running.md
+++ b/docs/services-running.md
@@ -19,7 +19,6 @@ These are the confirmed platform services running in K3s:
 The repo currently contains application manifests or overlays for:
 - **Blog**
 - **Glance**
-- **Homepage**
 - **Immich**
 - **Linkwarden**
 - **n8n**


### PR DESCRIPTION
## Summary

- remove Homepage from the top-level README application inventory
- remove Homepage from the focused running-services documentation

## Validation

- confirmed no Markdown files still reference Homepage
- checked all 38 local Markdown links
- ran `git diff --check`

## Scope

Documentation only. The Homepage Kubernetes manifests and certificate remain unchanged.
