### PR TITLE
feat: deploy Paperless

### DIFF
--- a/apps/base/paperless/deployment.yaml
+++ b/apps/base/paperless/deployment.yaml
@@ -1,0 +1,98 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: paperless
+  namespace: apps
+  labels:
+    app: paperless
+spec:
+  replicas: 1
+  strategy:
+    type: Recreate
+  selector:
+    matchLabels:
+      app: paperless
+  template:
+    metadata:
+      labels:
+        app: paperless
+    spec:
+      initContainers:
+        - name: volume-permissions
+          image: busybox:1.38
+          command: ["sh", "-c", "mkdir -p /paperless/data /paperless/media /paperless/export /paperless/consume && chown -R 1000:1000 /paperless"]
+          volumeMounts:
+            - name: paperless-data
+              mountPath: /paperless
+      containers:
+        - name: paperless
+          image: ghcr.io/paperless-ngx/paperless-ngx:2.20.15
+          ports:
+            - containerPort: 8000
+          env:
+            - name: PAPERLESS_URL
+              value: "https://paperless.ysonsbaolab.dev"
+            - name: PAPERLESS_TIME_ZONE
+              value: "Asia/Taipei"
+            - name: PAPERLESS_OCR_LANGUAGE
+              value: "eng+chi_tra"
+            - name: PAPERLESS_REDIS
+              value: "redis://paperless-redis-service.apps.svc.cluster.local:6379"
+            - name: PAPERLESS_DBHOST
+              value: "paperless-postgres-service.apps.svc.cluster.local"
+            - name: PAPERLESS_DBPORT
+              value: "5432"
+            - name: PAPERLESS_DBNAME
+              valueFrom:
+                secretKeyRef:
+                  name: paperless-secret
+                  key: POSTGRES_DB
+            - name: PAPERLESS_DBUSER
+              valueFrom:
+                secretKeyRef:
+                  name: paperless-secret
+                  key: PAPERLESS_DBUSER
+            - name: PAPERLESS_DBPASS
+              valueFrom:
+                secretKeyRef:
+                  name: paperless-secret
+                  key: PAPERLESS_DBPASS
+            - name: PAPERLESS_SECRET_KEY
+              valueFrom:
+                secretKeyRef:
+                  name: paperless-secret
+                  key: PAPERLESS_SECRET_KEY
+            - name: PAPERLESS_ADMIN_USER
+              valueFrom:
+                secretKeyRef:
+                  name: paperless-secret
+                  key: PAPERLESS_ADMIN_USER
+            - name: PAPERLESS_ADMIN_PASSWORD
+              valueFrom:
+                secretKeyRef:
+                  name: paperless-secret
+                  key: PAPERLESS_ADMIN_PASSWORD
+          volumeMounts:
+            - name: paperless-data
+              mountPath: /usr/src/paperless/data
+              subPath: data
+            - name: paperless-data
+              mountPath: /usr/src/paperless/media
+              subPath: media
+            - name: paperless-data
+              mountPath: /usr/src/paperless/export
+              subPath: export
+            - name: paperless-data
+              mountPath: /usr/src/paperless/consume
+              subPath: consume
+          resources:
+            requests:
+              cpu: 250m
+              memory: 512Mi
+            limits:
+              cpu: 1500m
+              memory: 2Gi
+      volumes:
+        - name: paperless-data
+          persistentVolumeClaim:
+            claimName: paperless-data-pvc-longhorn

--- a/apps/base/paperless/ingress.yaml
+++ b/apps/base/paperless/ingress.yaml
@@ -1,0 +1,17 @@
+# yaml-language-server: $schema=https://raw.githubusercontent.com/datreeio/CRDs-catalog/main/traefik.io/ingressroute_v1alpha1.json
+apiVersion: traefik.io/v1alpha1
+kind: IngressRoute
+metadata:
+  name: paperless-ingress
+  namespace: apps
+spec:
+  entryPoints:
+    - websecure
+  routes:
+    - match: Host(`paperless.ysonsbaolab.dev`)
+      kind: Rule
+      services:
+        - name: paperless-service
+          port: 8000
+  tls:
+    secretName: paperless-certificate-secret

--- a/apps/base/paperless/kustomization.yaml
+++ b/apps/base/paperless/kustomization.yaml
@@ -1,0 +1,13 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
+  - secret.yaml
+  - postgres-pvc.yaml
+  - postgres-deployment.yaml
+  - postgres-service.yaml
+  - redis-deployment.yaml
+  - redis-service.yaml
+  - paperless-pvc.yaml
+  - deployment.yaml
+  - service.yaml
+  - ingress.yaml

--- a/apps/base/paperless/paperless-pvc.yaml
+++ b/apps/base/paperless/paperless-pvc.yaml
@@ -1,0 +1,12 @@
+apiVersion: v1
+kind: PersistentVolumeClaim
+metadata:
+  name: paperless-data-pvc-longhorn
+  namespace: apps
+spec:
+  accessModes:
+    - ReadWriteOnce
+  storageClassName: longhorn
+  resources:
+    requests:
+      storage: 20Gi

--- a/apps/base/paperless/postgres-deployment.yaml
+++ b/apps/base/paperless/postgres-deployment.yaml
@@ -1,0 +1,44 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: paperless-postgres
+  namespace: apps
+  labels:
+    app: paperless-postgres
+spec:
+  replicas: 1
+  strategy:
+    type: Recreate
+  selector:
+    matchLabels:
+      app: paperless-postgres
+  template:
+    metadata:
+      labels:
+        app: paperless-postgres
+    spec:
+      containers:
+        - name: postgres
+          image: postgres:16-alpine
+          ports:
+            - containerPort: 5432
+          env:
+            - name: PGDATA
+              value: /var/lib/postgresql/data/pgdata
+          envFrom:
+            - secretRef:
+                name: paperless-secret
+          volumeMounts:
+            - name: postgres-data
+              mountPath: /var/lib/postgresql/data
+          resources:
+            requests:
+              cpu: 100m
+              memory: 256Mi
+            limits:
+              cpu: 500m
+              memory: 1Gi
+      volumes:
+        - name: postgres-data
+          persistentVolumeClaim:
+            claimName: paperless-postgres-pvc-longhorn

--- a/apps/base/paperless/postgres-pvc.yaml
+++ b/apps/base/paperless/postgres-pvc.yaml
@@ -1,0 +1,12 @@
+apiVersion: v1
+kind: PersistentVolumeClaim
+metadata:
+  name: paperless-postgres-pvc-longhorn
+  namespace: apps
+spec:
+  accessModes:
+    - ReadWriteOnce
+  storageClassName: longhorn
+  resources:
+    requests:
+      storage: 5Gi

--- a/apps/base/paperless/postgres-service.yaml
+++ b/apps/base/paperless/postgres-service.yaml
@@ -1,0 +1,12 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: paperless-postgres-service
+  namespace: apps
+spec:
+  type: ClusterIP
+  selector:
+    app: paperless-postgres
+  ports:
+    - port: 5432
+      targetPort: 5432

--- a/apps/base/paperless/redis-deployment.yaml
+++ b/apps/base/paperless/redis-deployment.yaml
@@ -1,0 +1,29 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: paperless-redis
+  namespace: apps
+  labels:
+    app: paperless-redis
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app: paperless-redis
+  template:
+    metadata:
+      labels:
+        app: paperless-redis
+    spec:
+      containers:
+        - name: redis
+          image: redis:7-alpine
+          ports:
+            - containerPort: 6379
+          resources:
+            requests:
+              cpu: 50m
+              memory: 64Mi
+            limits:
+              cpu: 250m
+              memory: 256Mi

--- a/apps/base/paperless/redis-service.yaml
+++ b/apps/base/paperless/redis-service.yaml
@@ -1,0 +1,12 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: paperless-redis-service
+  namespace: apps
+spec:
+  type: ClusterIP
+  selector:
+    app: paperless-redis
+  ports:
+    - port: 6379
+      targetPort: 6379

--- a/apps/base/paperless/secret.yaml
+++ b/apps/base/paperless/secret.yaml
@@ -1,0 +1,15 @@
+apiVersion: v1
+kind: Secret
+metadata:
+  name: paperless-secret
+  namespace: apps
+type: Opaque
+stringData:
+  PAPERLESS_SECRET_KEY: "replace-me-with-a-long-random-secret-key"
+  PAPERLESS_ADMIN_USER: "admin"
+  PAPERLESS_ADMIN_PASSWORD: "paperless"
+  PAPERLESS_DBUSER: "paperless"
+  PAPERLESS_DBPASS: "paperless"
+  POSTGRES_USER: "paperless"
+  POSTGRES_PASSWORD: "paperless"
+  POSTGRES_DB: "paperless"

--- a/apps/base/paperless/service.yaml
+++ b/apps/base/paperless/service.yaml
@@ -1,0 +1,12 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: paperless-service
+  namespace: apps
+spec:
+  type: ClusterIP
+  selector:
+    app: paperless
+  ports:
+    - port: 8000
+      targetPort: 8000

--- a/apps/the-big-ship/kustomization.yaml
+++ b/apps/the-big-ship/kustomization.yaml
@@ -1,0 +1,14 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
+  - ai-agent-view
+  - blog
+  - default
+  - external-service
+  - glance
+  - immich
+  - n8n
+  - paperless
+  - test
+  - vaultwarden
+  - vaultwarden-testing

--- a/apps/the-big-ship/paperless/kustomization.yaml
+++ b/apps/the-big-ship/paperless/kustomization.yaml
@@ -1,0 +1,5 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+namespace: apps
+resources:
+  - ../../base/paperless/

--- a/clusters/the-big-ship/kustomization.yaml
+++ b/clusters/the-big-ship/kustomization.yaml
@@ -1,0 +1,10 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
+  - flux-system
+  - infrastructure-kus.yaml
+  - database-kus.yaml
+  - apps-kus.yaml
+  - hugo-image.yaml
+  - hugo-policy.yaml
+  - hugo-auto-update.yaml

--- a/database/the-big-ship/kustomization.yaml
+++ b/database/the-big-ship/kustomization.yaml
@@ -1,0 +1,8 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
+  - couchdb
+  - immich
+  - linkwarden
+  - playground
+  - rss-news

--- a/infrastructure/the-big-ship/certificate/kustomization.yaml
+++ b/infrastructure/the-big-ship/certificate/kustomization.yaml
@@ -2,9 +2,9 @@ apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 resources:
   - blog-cert.yaml
-  - homepage-cert.yaml
   - vaultwarden-cert.yaml
   - n8n-cert.yaml
+  - paperless-cert.yaml
   - immich-cert.yaml
   - glance-cert.yaml
   - longhorn-cert.yaml

--- a/infrastructure/the-big-ship/certificate/paperless-cert.yaml
+++ b/infrastructure/the-big-ship/certificate/paperless-cert.yaml
@@ -1,0 +1,12 @@
+apiVersion: cert-manager.io/v1
+kind: Certificate
+metadata:
+  name: paperless-ingress-certificate
+  namespace: apps
+spec:
+  secretName: paperless-certificate-secret
+  issuerRef:
+    name: cloudflare-cluster-issuer
+    kind: ClusterIssuer
+  dnsNames:
+    - paperless.ysonsbaolab.dev

--- a/infrastructure/the-big-ship/kustomization.yaml
+++ b/infrastructure/the-big-ship/kustomization.yaml
@@ -1,0 +1,14 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
+  - cert-manager
+  - external-secrets
+  - cloudnative-pg
+  - traefik
+  - cloudflared
+  - longhorn
+  - nfs-storageclass
+  - monitoring
+  - descheduler
+  - dozzle
+  - certificate


### PR DESCRIPTION
## Summary
- Deploy Paperless-ngx at `paperless.ysonsbaolab.dev`
- Add app-local PostgreSQL and Redis for first-pass evaluation
- Add Longhorn PVCs for Paperless data and PostgreSQL data
- Use a dummy in-repo Kubernetes Secret for now, per testing preference, to be replaced with ExternalSecret after app validation
- Add missing root Kustomization wiring for cluster/apps/database/infrastructure Flux paths
- Add Paperless cert-manager Certificate and remove stale missing `homepage-cert.yaml` reference from the certificate kustomization

## Notes
- Paperless image is pinned to `ghcr.io/paperless-ngx/paperless-ngx:2.20.15`
- Dummy login is `admin` / `paperless`; replace before keeping the app long-term
- Secret values are intentionally placeholders, not production credentials
- PostgreSQL is app-local in `apps` namespace to keep this trial self-contained; can be migrated to CNPG/ExternalSecret later if you keep Paperless

## Validation
```bash
kubectl kustomize apps/the-big-ship
kubectl kustomize infrastructure/the-big-ship
kubectl kustomize database/the-big-ship
kubectl kustomize clusters/the-big-ship
git diff --check
```

Rendered checks confirmed:
- Paperless Deployment present
- Paperless PostgreSQL present
- Paperless Redis present
- Dummy `paperless-secret` present
- `paperless.ysonsbaolab.dev` IngressRoute present
- Paperless image pinned to `2.20.15`
