### PR TITLE
fix: align external-secrets chart for dependency PR #413

### DIFF
--- a/infrastructure/base/external-secrets/helmrelease.yaml
+++ b/infrastructure/base/external-secrets/helmrelease.yaml
@@ -10,7 +10,7 @@ spec:
   chart:
     spec:
       chart: external-secrets
-      version: 2.8.0
+      version: 2.9.0
       sourceRef:
         kind: HelmRepository
         name: external-secrets


### PR DESCRIPTION
## Summary
- Aligns the external-secrets Helm chart version with Renovate PR #413's CRD GitRepository tag update.
- Keeps the separately managed CRDs and controller/chart on v2.9.0 together.

## Dependency PR
- Companion fix for #413

## Validation
- `git diff --check origin/main...fix/dep-pr-413-external-secrets-chart`

Do not merge #413 before this companion fix is merged or applied.