### PR TITLE
fix: enable monitoring CRD upgrade job for dependency PR #404

### DIFF
--- a/infrastructure/base/monitoring/helmrelease.yaml
+++ b/infrastructure/base/monitoring/helmrelease.yaml
@@ -28,6 +28,8 @@ spec:
     ## ----------------------------------------------------
     crds:
       enabled: true
+      upgradeJob:
+        enabled: true
 
     prometheusOperator:
       enabled: true


### PR DESCRIPTION
## Summary
- Enables the kube-prometheus-stack CRD upgrade job for the major chart/operator jump in Renovate PR #404.
- This helps Flux/Helm reconcile Prometheus Operator CRD changes during the 86.x -> 88.x update.

## Dependency PR
- Companion fix for #404

## Validation
- `git diff --check origin/main...fix/dep-pr-404-kube-prometheus-crds`

Do not merge #404 before this companion fix is merged or applied.